### PR TITLE
modified gitignore to ignore DS_Store extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /log/*
 !/log/.keep
 /tmp
+.DS_Store


### PR DESCRIPTION
DS_Store isn't something good to commit to the repo. It holds Mac file graphics and locations and clutters up the results of a git status.
