### PR TITLE
changed to_destination links to ask for login using the pop-up modal

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
   	@user = User.find_by(email: params[:email])
   	if @user.authenticate(params[:password])
   		session[:user_id] = @user.id 
-  		redirect_to "/users/#{@user.id}"
+  		redirect_to :back
   	else
   		flash[:errors] = ["Invalid email or password."]
   		redirect_to :back

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -61,25 +61,49 @@
 <div id="places">
    <div class="row">
      <div class="col s4">
+      <% if current_user %>
        <a href="trips/Los_Angeles/to_destination"><img class="responsive-img" src="losangeles.png" alt="Los Angeles"></a>
+      <% else %>
+       <a class = "modal-trigger" href="#modal2" data-target = "#modal2"><img class="responsive-img" src="losangeles.png" alt="Los Angeles"></a>
+      <% end %>
      </div>
      <div class="col s4">
-      <a href="trips/Paris/to_destination"><img class="responsive-img" src="paris.png" alt="Paris"></a>
+      <% if current_user %>
+       <a href="trips/Paris/to_destination"><img class="responsive-img" src="paris.png" alt="Los Angeles"></a>
+      <% else %>
+       <a class = "modal-trigger" href="#modal2" data-target = "#modal2"><img class="responsive-img" src="paris.png" alt="Los Angeles"></a>
+      <% end %>
      </div>
      <div class="col s4">
+      <% if current_user %>
        <a href="trips/Chicago/to_destination"><img class="responsive-img" src="chicago.png" alt="Chicago"></a>
+      <% else %>
+       <a class = "modal-trigger" href="#modal2" data-target = "#modal2"><img class="responsive-img" src="chicago.png" alt="Chicago"></a>
+      <% end %>
      </div>
    </div>
 
    <div class="row">
      <div class="col s4">
+      <% if current_user %>
        <a href="trips/London/to_destination"><img class="responsive-img" src="london.png" alt="London"></a>
+      <% else %>
+       <a class = "modal-trigger" href="#modal2" data-target = "#modal2"><img class="responsive-img" src="london.png" alt="London"></a>
+      <% end %>
      </div>
      <div class="col s4">
+      <% if current_user %>
        <a href="trips/San_Francisco/to_destination"><img class="responsive-img" src="sanfrancisco.png" alt="San Francisco"></a>
+      <% else %>
+       <a class = "modal-trigger" href="#modal2" data-target = "#modal2"><img class="responsive-img" src="sanfrancisco.png" alt="San Francisco"></a>
+      <% end %>
      </div>
      <div class="col s4">
+      <% if current_user %>
        <a href="trips/Seoul/to_destination"><img class="responsive-img" src="seoul.png" alt="Seoul"></a>
+      <% else %>
+       <a class = "modal-trigger" href="#modal2" data-target = "#modal2"><img class="responsive-img" src="seoul.png" alt="Seoul"></a>
+      <% end %>
      </div>
    </div>
 </div>


### PR DESCRIPTION
If the user is not logged in and tries to access the destination links at the bottom (Los Angeles, Seoul, etc), then we get a nasty Rails error message. I have created a conditional statement in the sessions#index view (the root homepage in /app/views/sessions/index.html.erb) so that if current_user is nil, then the links cause the popup modal for login to show up instead of redirecting to the to_destination view.

The second commit changes how the user is redirected upon login. Since we require the user to login before going to the to_destination links on the front page, it is bad UX to have the user be sent to their profile page, then be forced to click home again in order to see the to_destination links. The new function simply redirects to the previous page upon login.
